### PR TITLE
Update to brewblox-service 0.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,25 +21,8 @@ before_deploy:
   && docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 deploy:
-
-  # Deploy to PyPi on tagged commits
-  - provider: pypi
-    user: $PYPI_USER
-    password: $PYPI_PASSWORD
-    skip_cleanup: true
-    on:
-      tags: true
-
-  # Deploy dev version to PyPi on any push to an upstream development branch
-  - provider: pypi
-    user: $PYPI_USER
-    password: $PYPI_PASSWORD
-    skip_cleanup: true
-    on:
-      tags: false
-      repo: $GITHUB_REPO
-      all_branches: true
-      condition: $TRAVIS_BRANCH != master
+  # Note: Docker Hub deployment is intentionally done before PyPi deployment
+  # Docker Hub allows overwriting versions, PyPi does not
 
   # Deploy "latest" and version tag to Docker Hub on tagged commits
   - provider: script
@@ -69,6 +52,25 @@ deploy:
       --image rpi-docker
       --name "$DOCKER_REPO"
       --tags rpi-$TRAVIS_BRANCH
+    skip_cleanup: true
+    on:
+      tags: false
+      repo: $GITHUB_REPO
+      all_branches: true
+      condition: $TRAVIS_BRANCH != master
+
+  # Deploy to PyPi on tagged commits
+  - provider: pypi
+    user: $PYPI_USER
+    password: $PYPI_PASSWORD
+    skip_cleanup: true
+    on:
+      tags: true
+
+  # Deploy dev version to PyPi on any push to an upstream development branch
+  - provider: pypi
+    user: $PYPI_USER
+    password: $PYPI_PASSWORD
     skip_cleanup: true
     on:
       tags: false

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 
 [packages]
 
-brewblox-service = "~=0.9"
+brewblox-service = "~=0.10"
 aioinflux = "~=0.3.0"
 dpath = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "90eda1b8114765812a9620d1d6917b97e9d4065d767960c658a315c58f781ccf"
+            "sha256": "5f089ddbf9a33dfd493dc9698d165cb7e04aba4916925728e6783b4c27f5eb19"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -80,10 +80,10 @@
         },
         "brewblox-service": {
             "hashes": [
-                "sha256:900ce973fcb1736526014a8f862381663447e6677e9374746ce0eb4fcfa01c7b"
+                "sha256:0d21b6ed50a021c3cbd4ceaa3ebd36c99bbfee7a2658c511d9b914664e03bfe8"
             ],
             "index": "pypi",
-            "version": "==0.9.0"
+            "version": "==0.10.0"
         },
         "cchardet": {
             "hashes": [
@@ -257,6 +257,13 @@
             "index": "pypi",
             "version": "==0.12.0"
         },
+        "atomicwrites": {
+            "hashes": [
+                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
+                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+            ],
+            "version": "==1.1.5"
+        },
         "attrs": {
             "hashes": [
                 "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
@@ -404,10 +411,10 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:54713b26c97538db6ff0703a12b19aeaeb60b5e599de542e7fca0ec83b9038e8",
-                "sha256:829230122facf05a5f81a6d4dfe6454a04978ea3746853b2b84567ecf8e5c526"
+                "sha256:39555d023af3200d004d09e51b4dd9fdd828baa863cded3fd6ba2f29f757ae2d",
+                "sha256:c76e93f3145a44812955e8d46cdd302d8a45fbfc7bf22be24fe231f9d8d8853a"
             ],
-            "version": "==3.5.1"
+            "version": "==3.6.0"
         },
         "pytest-aiohttp": {
             "hashes": [

--- a/brewblox_history/influx.py
+++ b/brewblox_history/influx.py
@@ -50,11 +50,11 @@ class QueryClient(features.ServiceFeature):
         super().__init__(app)
         self._client: InfluxDBClient = None
 
-    async def start(self, app: web.Application):
-        await self.close()
+    async def startup(self, app: web.Application):
+        await self.shutdown()
         self._client = InfluxDBClient(host=INFLUX_HOST, loop=app.loop)
 
-    async def close(self, *_):
+    async def shutdown(self, *_):
         if self._client:
             await self._client.close()
             self._client = None
@@ -87,11 +87,11 @@ class InfluxWriter(features.ServiceFeature):
     def is_running(self) -> bool:
         return self._task and not self._task.done()
 
-    async def start(self, app: web.Application):
-        await self.close()
+    async def startup(self, app: web.Application):
+        await self.shutdown()
         self._task = app.loop.create_task(self._run(app.loop))
 
-    async def close(self, *_):
+    async def shutdown(self, *_):
         try:
             self._task.cancel()
             await self._task
@@ -224,14 +224,14 @@ class EventRelay(features.ServiceFeature):
     """
 
     def __init__(self, app: web.Application):
-        super().__init__(None)  # we don't use start/close functions
+        super().__init__(None)  # we don't use startup/shutdown functions
         self._listener = events.get_listener(app)
         self._writer = get_writer(app)
 
-    async def start(self, *_):
+    async def startup(self, *_):
         pass
 
-    async def close(self, *_):
+    async def shutdown(self, *_):
         pass
 
     def subscribe(self, *args, **kwargs):


### PR DESCRIPTION
Changes: 
* start()/close() functions are renamed to startup()/shutdown(), after they were deprecated in brewblox-service