### PR TITLE
Add epoch argument to queries.

### DIFF
--- a/brewblox_history/influx.py
+++ b/brewblox_history/influx.py
@@ -12,7 +12,7 @@ LOGGER = brewblox_logger(__name__)
 
 
 INFLUX_HOST = 'influx'
-RECONNECT_INTERVAL_S = 1
+RECONNECT_INTERVAL_S = 5
 MAX_PENDING_POINTS = 5000
 
 DEFAULT_DATABASE = 'brewblox'

--- a/brewblox_history/influx.py
+++ b/brewblox_history/influx.py
@@ -17,6 +17,7 @@ MAX_PENDING_POINTS = 5000
 
 DEFAULT_DATABASE = 'brewblox'
 DEFAULT_POLICY = 'autogen'
+DEFAULT_EPOCH = 'ns'
 COMBINED_POINTS_FIELD = ' Combined Influx points'
 
 
@@ -45,7 +46,8 @@ class QueryClient(features.ServiceFeature):
 
     async def query(self, query: str, **kwargs):
         database = kwargs.get('database', DEFAULT_DATABASE)
-        return await self._client.query(query.format(**kwargs), db=database)
+        epoch = kwargs.get('epoch', DEFAULT_EPOCH)
+        return await self._client.query(query.format(**kwargs), db=database, epoch=epoch)
 
 
 class InfluxWriter(repeater.RepeaterFeature):

--- a/brewblox_history/queries.py
+++ b/brewblox_history/queries.py
@@ -109,6 +109,7 @@ async def configure_params(client: influx.QueryClient,
                            limit: Optional[int] = None,
                            policy: Optional[str] = None,
                            approx_points: Optional[int] = DEFAULT_APPROX_POINTS,
+                           epoch: Optional[str] = None,
                            **_  # allow, but discard all other kwargs
                            ) -> dict:
     start = nanosecond_date(start)
@@ -125,7 +126,7 @@ async def configure_params(client: influx.QueryClient,
     fields = format_fields(fields, prefix)
 
     return _prune(locals(), ['query', 'database', 'policy', 'measurement', 'fields',
-                             'start', 'duration', 'end', 'order_by', 'limit', 'prefix'])
+                             'start', 'duration', 'end', 'order_by', 'limit', 'prefix', 'epoch'])
 
 
 def build_query(params: dict):
@@ -163,6 +164,7 @@ async def run_query(client: influx.QueryClient, query: str, params: dict):
 
     response['database'] = params.get('database') or influx.DEFAULT_DATABASE
     response['policy'] = params.get('policy') or influx.DEFAULT_POLICY
+    response['epoch'] = params.get('epoch') or influx.DEFAULT_EPOCH
     return response
 
 

--- a/brewblox_history/schemas.py
+++ b/brewblox_history/schemas.py
@@ -2,7 +2,8 @@
 Schemas used in API endpoints
 """
 
-from marshmallow import Schema, ValidationError, fields, validates_schema
+from marshmallow import (Schema, ValidationError, fields, validate,
+                         validates_schema)
 
 
 class ObjectsQuerySchema(Schema):
@@ -22,6 +23,8 @@ class HistoryQuerySchema(HistoryMeasurementSchema):
                           required=False)
     approx_points = fields.Integer(required=False)
     policy = fields.String(required=False)
+    epoch = fields.String(required=False,
+                          validate=validate.OneOf(['ns', 'u', 'µ', 'ms', 's', 'm', 'h']))
 
 
 class HistoryBoundedValuesSchema(HistoryQuerySchema):

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -211,7 +211,7 @@ async def test_value_data_format(app, client, query_mock, values_result):
         'ORDER BY {order_by} LIMIT {limit}'
     ),
     (
-        {'duration': 'eternal', 'limit': 1},
+        {'duration': 'eternal', 'limit': 1, 'epoch': 'ms'},
         'SELECT {fields} FROM "{database}"."{policy}"."{measurement}" ' +
         'WHERE time >= now() - {duration} LIMIT {limit}'
     ),


### PR DESCRIPTION
Acceptable values are [ns,u,µ,ms,s,m,h]. The default value is ns.
Argument is forwarded to the Influx API: https://docs.influxdata.com/influxdb/v1.8/tools/api/#query-string-parameters-1

Resolves #142