### PR TITLE
limit victoria exports to 1000 rows per line

### DIFF
--- a/brewblox_history/timeseries_api.py
+++ b/brewblox_history/timeseries_api.py
@@ -122,6 +122,7 @@ class CsvView(VictoriaView):
             }
         )
         await response.prepare(self.request)
+        response.enable_chunked_encoding()
 
         async for line in self.victoria.csv(args):  # pragma: no branch
             await response.write(line.encode())


### PR DESCRIPTION
An unbounded /api/v1/export call would raise an aiohttp ValueError('Chunk size too big').
The API now explicitly chunks output, and limits input to 1000 rows/json line.﻿
